### PR TITLE
pin numpy<1.24.0, install mintpy with conda in all relavent yamls

### DIFF
--- a/Environment_Configs/insar_analysis_env.yml
+++ b/Environment_Configs/insar_analysis_env.yml
@@ -27,7 +27,7 @@ dependencies:
   - mgrs
   - mintpy
   - netcdf4
-  - numpy
+  - numpy<1.24.0
   - openmp
   - opensarlab_lib
   - pip

--- a/Environment_Configs/nisar_se_env.yml
+++ b/Environment_Configs/nisar_se_env.yml
@@ -1,8 +1,6 @@
 name: NISAR_SE
 channels:
-  - opensarlab
   - conda-forge
-  - pyrocko
 dependencies:
   - asf_search
   - awscli
@@ -17,9 +15,10 @@ dependencies:
   - ipywidgets<8.0.0
   - isce2
   - kernda
-  - mintpy=1.3.3.dev1
+  - mintpy
   - nbdime
   - netcdf4
+  - numpy<1.24.0
   - opensarlab_lib
   - pip
   - pv
@@ -29,7 +28,6 @@ dependencies:
   - rasterio
   - traitlets==5.1.1
   - pip:
-    - git+https://github.com/pyrocko/kite
+    - h5py<3
     - ipynb
-    - okada_wrapper
     - url-widget

--- a/Environment_Configs/unavco_env.yml
+++ b/Environment_Configs/unavco_env.yml
@@ -1,6 +1,7 @@
 name: unavco
 channels:
   - conda-forge
+  - pyrocko
 dependencies:
   - python>=3.6,<3.9
   - boto3

--- a/Environment_Configs/unavco_env.yml
+++ b/Environment_Configs/unavco_env.yml
@@ -1,7 +1,6 @@
 name: unavco
 channels:
   - conda-forge
-  - pyrocko
 dependencies:
   - python>=3.6,<3.9
   - boto3
@@ -23,8 +22,9 @@ dependencies:
   - kernda
   - lxml
   - matplotlib
+  - mintpy
   - netcdf4
-  - numpy
+  - numpy<1.24.0
   - openmp
   - opensarlab_lib
   - pip
@@ -43,9 +43,6 @@ dependencies:
   - xarray
   - zarr
   - pip:
-    - git+https://github.com/pyrocko/kite
     - h5py<3
     - ipynb
-    - mintpy
-    - okada_wrapper
     - url-widget


### PR DESCRIPTION
- pin numpy<1.24.0 so fully deprecated numpy data types dont break mintpy
- all mintpy yamls should install current version of mintpy with conda (no opensarlab versions)