### PR TITLE
matplotlib<3.7.0

### DIFF
--- a/Environment_Configs/autorift_env.yml
+++ b/Environment_Configs/autorift_env.yml
@@ -10,6 +10,6 @@ dependencies:
   - pandas
   - jupyterlab
   - ipywidgets<8.0.0
-  - matplotlib
+  - matplotlib<3.7.0
   - ipympl
   - jupyterlab

--- a/Environment_Configs/hydrosar_env.yml
+++ b/Environment_Configs/hydrosar_env.yml
@@ -18,7 +18,7 @@ dependencies:
   - jupyterlab
   - ipywidgets<8.0.0
   - kernda
-  - matplotlib
+  - matplotlib<3.7.0
   - mgrs
   - numpy
   - oauth2client

--- a/Environment_Configs/insar_analysis_env.yml
+++ b/Environment_Configs/insar_analysis_env.yml
@@ -23,7 +23,7 @@ dependencies:
   - ipywidgets<8.0.0
   - kernda
   - lxml
-  - matplotlib
+  - matplotlib<3.7.0
   - mgrs
   - mintpy
   - netcdf4

--- a/Environment_Configs/machine_learning_env.yml
+++ b/Environment_Configs/machine_learning_env.yml
@@ -10,7 +10,7 @@ dependencies:
   - jupyterlab
   - ipywidgets<8.0.0
   - kernda
-  - matplotlib
+  - matplotlib<3.7.0
   - mgrs
   - numpy
   - opensarlab_lib

--- a/Environment_Configs/nisar_se_env.yml
+++ b/Environment_Configs/nisar_se_env.yml
@@ -16,6 +16,7 @@ dependencies:
   - ipywidgets<8.0.0
   - isce2
   - kernda
+  - matplotlib<3.7.0
   - mintpy
   - nbdime
   - netcdf4

--- a/Environment_Configs/rtc_analysis_env.yml
+++ b/Environment_Configs/rtc_analysis_env.yml
@@ -11,7 +11,7 @@ dependencies:
   - jupyterlab
   - ipywidgets<8.0.0
   - kernda
-  - matplotlib
+  - matplotlib<3.7.0
   - mgrs
   - netcdf4
   - numpy

--- a/Environment_Configs/train_env.yml
+++ b/Environment_Configs/train_env.yml
@@ -13,7 +13,7 @@ dependencies:
   - ipywidgets<8.0.0
   - kernda
   - lxml
-  - matplotlib
+  - matplotlib<3.7.0
   - netcdf4
   - numpy
   - opensarlab_lib

--- a/Environment_Configs/unavco_env.yml
+++ b/Environment_Configs/unavco_env.yml
@@ -22,7 +22,7 @@ dependencies:
   - ipywidgets<8.0.0
   - kernda
   - lxml
-  - matplotlib
+  - matplotlib<3.7.0
   - mintpy
   - netcdf4
   - numpy<1.24.0


### PR DESCRIPTION
- pinning matplotlib<3.7.0

matplotlib released a development version to conda-forge. It's breaking our AOI and Line selector widgets and their example code fails. We will need to update our code to account for deprecations and changes but we will wait for a stable release with working examples. 