### PR TITLE
add pip cache purge, unpinned h5py conda install into insar_analysis env

### DIFF
--- a/Create_OSL_Conda_Environments.ipynb
+++ b/Create_OSL_Conda_Environments.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -26,6 +27,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -42,6 +44,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -72,6 +75,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -123,6 +127,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -145,6 +150,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -182,6 +188,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -199,10 +206,12 @@
    },
    "outputs": [],
    "source": [
-    "!mamba clean -p -t --yes"
+    "!mamba clean -p -t --yes\n",
+    "!pip cache purge"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "pycharm": {

--- a/Environment_Configs/insar_analysis_env.yml
+++ b/Environment_Configs/insar_analysis_env.yml
@@ -13,6 +13,7 @@ dependencies:
   - defusedxml
   - ecCodes
   - geopandas
+  - h5py
   - hyp3_sdk
   - hyp3lib=1.4.1
   - ipympl
@@ -46,6 +47,5 @@ dependencies:
   - xarray
   - zarr
   - pip:
-    - h5py<3
     - url-widget
     


### PR DESCRIPTION
- conda clean does not clear pip caches
    - add pip cache purge to Create_OSL_Conda_Environments.ipynb
- update insar_analysis_env.yml to avoid broken h5py installation
    -  move h5py from pip to conda dependency section and unpin version