### PR TITLE
earthscope2023: simplify mintpy installation

### DIFF
--- a/Environment_Configs/earthscope_insar_env.yml
+++ b/Environment_Configs/earthscope_insar_env.yml
@@ -6,14 +6,9 @@ dependencies:
   - python
   - boto3
   - cartopy
-  - cdsapi
-  - cvxopt
   - cython
-  - dask>=1.0
-  - dask-jobqueue>=0.3
-  - defusedxml
-  - ecCodes
   - fortran-compiler
+  - h5py
   - hyp3lib=1.4.1
   - hyp3_sdk
   - ipympl
@@ -31,11 +26,7 @@ dependencies:
   - opensarlab_lib
   - pip
   - pv
-  - pygrib
-  - pyhdf
-  - pykdtree
   - pyproj
-  - pyresample
   - pyrocko
   - rioxarray
   - scikit-image
@@ -43,11 +34,8 @@ dependencies:
   - shapely
   - traitlets==5.1.1
   - utm
-  - xarray
-  - zarr
   - pip:
-    - h5py
-    - ipynb
     - url-widget
     - okada_wrapper
     - kite
+

--- a/Scripts/earthscope_insar.sh
+++ b/Scripts/earthscope_insar.sh
@@ -27,31 +27,6 @@ path="$SITE_PACKAGES"/isce/applications:"$LOCAL"/envs/"$NAME"/bin:$path
 # set ISCE_HOME
 conda env config vars set -n $NAME ISCE_HOME="$SITE_PACKAGES"/isce
 
-######## Install MintPy ########
-
-MINTPY_HOME="$LOCAL"/MintPy
-PYAPS_HOME="$LOCAL"/PyAPS
-
-# set MintPy env variables
-conda env config vars set -n $NAME MINTPY_HOME="$MINTPY_HOME"
-conda env config vars set -n $NAME PYAPS_HOME="$PYAPS_HOME"
-
-#update local path and pythonpath variables
-path="$MINTPY_HOME"/mintpy:"$path"
-pythonpath="$MINTPY_HOME":"$PYAPS_HOME":"$pythonpath"
-
-# clone MintPy
-if [ ! -d "$MINTPY_HOME" ]
-then
-    git clone -b v1.3.1 --depth=1 --single-branch https://github.com/insarlab/MintPy.git "$MINTPY_HOME"
-fi
-
-# clone pyaps
-if [ ! -d "$PYAPS_HOME" ]
-then
-    git clone -b main --depth=1 --single-branch https://github.com/yunjunz/PyAPS.git "$PYAPS_HOME"
-fi
-
 ######## Install ARIA-Tools ########
 
 # clone the ARIA-Tools repo and build ARIA-Tools


### PR DESCRIPTION
This PR simplifies the mintpy related code installation for the 2023 EarthScope ISCE+ short course. Local testings on OSL to create the conda environment and to run the mintpy notebook passed without issue.

+ `earthscope_insar_env.yml`: remove mintpy dependencies as they will be installed through mintpy and they are not used directly in notebooks. 

+ `earthscope_insar.sh`: remove mintpy setup as it's included in conda install mintpy