### PR TITLE
correct pip installed mintpy dep in locked nisar_se env

### DIFF
--- a/Locked_Environment_Configs/locked_nisar_se_env.yml
+++ b/Locked_Environment_Configs/locked_nisar_se_env.yml
@@ -384,7 +384,7 @@ dependencies:
       - lxml==5.2.0
       - markdown-it-py==3.0.0
       - mdurl==0.1.2
-      - mintpy==1.5.3.post21
+      - git+https://github.com/insarlab/MintPy.git@5683092
       - msgpack==1.0.8
       - partd==1.4.1
       - pyaps3==0.3.2


### PR DESCRIPTION
Fix issue in locked env yaml where, if you install something with pip in a conda environment.yaml from a git commit like this:

`git+https://github.com/insarlab/MintPy.git@5683092`

and then export the env to a pinned yaml, it is turned into something like this:

`mintpy==1.5.3.post21`

which cannot be found and fails.