### PR TITLE
fix breaking earthscope_insar env by pinning pyrocko==2023.10.11

### DIFF
--- a/Environment_Configs/earthscope_insar_env.yml
+++ b/Environment_Configs/earthscope_insar_env.yml
@@ -6,29 +6,17 @@ dependencies:
   - asf_search
   - autorift
   - boto3
-  - cartopy
-  - h5py
   - hyp3_sdk
+  - ipykernel
   - ipympl
   - isce2
-  - jupyterlab
-  - ipywidgets
-  - matplotlib 
-  - mintpy==1.5.1 # Ref point stored in old UTM after lat/lon conversion. Waiting resolution to https://github.com/insarlab/MintPy/issues/1098
-                  # After PR merged, when we update, we may need to stop projecting to lat/lon in Prepare_HyP3_InSAR_Stack_for_MintPy.ipynb
+  - mintpy
   - netcdf4
-  - numpy
-  - opencv
   - pip
   - pv
-  - pyproj
-  - pyrocko
+  - pyrocko==2023.10.11
   - sardem
-  - scikit-image
-  - scipy
-  - shapely==2.0.1
   - xarray
-  - utm
   - pip:
     - url-widget
     - okada_wrapper

--- a/Locked_Environment_Configs/locked_earthscope_insar_env.yml
+++ b/Locked_Environment_Configs/locked_earthscope_insar_env.yml
@@ -6,18 +6,12 @@ dependencies:
   - _libgcc_mutex=0.1=conda_forge
   - _openmp_mutex=4.5=2_gnu
   - alsa-lib=1.2.8=h166bdaf_0
-  - anyio=4.3.0=pyhd8ed1ab_0
   - aom=3.5.0=h27087fc_0
-  - argcomplete=3.2.2=pyhd8ed1ab_0
-  - argon2-cffi=23.1.0=pyhd8ed1ab_0
-  - argon2-cffi-bindings=21.2.0=py311h459d7ec_4
-  - arrow=1.3.0=pyhd8ed1ab_0
-  - asf_search=7.0.4=pyhd8ed1ab_0
-  - asf_search-base=7.0.4=pyhd8ed1ab_0
+  - argcomplete=3.2.3=pyhd8ed1ab_0
+  - asf_search=7.0.8=pyhd8ed1ab_0
+  - asf_search-base=7.0.8=pyhd8ed1ab_0
   - asttokens=2.4.1=pyhd8ed1ab_0
-  - async-lru=2.0.4=pyhd8ed1ab_0
   - attr=2.5.1=h166bdaf_1
-  - attrs=23.2.0=pyh71513ae_0
   - autorift=1.5.0=py311hc8c2753_2
   - aws-c-auth=0.7.0=hf8751d9_2
   - aws-c-cal=0.6.0=h93469e0_0
@@ -32,21 +26,18 @@ dependencies:
   - aws-checksums=0.1.16=h862ab75_1
   - aws-crt-cpp=0.20.3=he9c0e7f_4
   - aws-sdk-cpp=1.10.57=hbc2ea52_17
-  - babel=2.14.0=pyhd8ed1ab_0
-  - beautifulsoup4=4.12.3=pyha770c72_0
-  - bleach=6.1.0=pyhd8ed1ab_0
   - blosc=1.21.5=h0f2a231_0
-  - bokeh=3.3.4=pyhd8ed1ab_0
+  - bokeh=3.4.0=pyhd8ed1ab_0
   - boost-cpp=1.78.0=h5adbc97_2
-  - boto3=1.34.46=pyhd8ed1ab_0
-  - botocore=1.34.47=pyge310_1234567_0
+  - boto3=1.34.81=pyhd8ed1ab_0
+  - botocore=1.34.81=pyge310_1234567_0
   - brotli=1.0.9=h166bdaf_9
   - brotli-bin=1.0.9=h166bdaf_9
   - brotli-python=1.0.9=py311ha362b79_9
   - brunsli=0.1=h9c3ff4c_0
   - bzip2=1.0.8=hd590300_5
-  - c-ares=1.26.0=hd590300_0
-  - c-blosc2=2.13.2=hb4ffafa_0
+  - c-ares=1.28.1=hd590300_0
+  - c-blosc2=2.14.4=hb4ffafa_0
   - ca-certificates=2024.2.2=hbcca054_0
   - cached-property=1.5.2=hd8ed1ab_1
   - cached_property=1.5.2=pyha770c72_1
@@ -63,34 +54,33 @@ dependencies:
   - click=8.1.7=unix_pyh707e725_0
   - cloudpickle=3.0.0=pyhd8ed1ab_0
   - colorama=0.4.6=pyhd8ed1ab_0
-  - comm=0.2.1=pyhd8ed1ab_0
+  - comm=0.2.2=pyhd8ed1ab_0
   - configobj=5.0.8=pyhd8ed1ab_0
-  - contourpy=1.2.0=py311h9547e67_0
+  - contourpy=1.2.1=py311h9547e67_0
   - curl=8.1.2=h409715c_0
   - cvxopt=1.3.2=py311h2b3fd1d_1
   - cycler=0.12.1=pyhd8ed1ab_0
   - cytoolz=0.12.3=py311h459d7ec_0
-  - dask=2024.2.0=pyhd8ed1ab_0
-  - dask-core=2024.2.0=pyhd8ed1ab_0
-  - dask-jobqueue=0.8.2=pyhd8ed1ab_0
+  - dask=2024.4.1=pyhd8ed1ab_0
+  - dask-core=2024.4.1=pyhd8ed1ab_0
+  - dask-expr=1.0.11=pyhd8ed1ab_0
+  - dask-jobqueue=0.8.5=pyhd8ed1ab_0
   - dateparser=1.2.0=pyhd8ed1ab_0
   - dav1d=1.2.1=hd590300_0
   - dbus=1.13.6=h5008d03_3
   - debugpy=1.8.1=py311hb755f60_0
   - decorator=5.1.1=pyhd8ed1ab_0
-  - defusedxml=0.7.1=pyhd8ed1ab_0
   - distlib=0.3.8=pyhd8ed1ab_0
-  - distributed=2024.2.0=pyhd8ed1ab_0
+  - distributed=2024.4.1=pyhd8ed1ab_0
   - donfig=0.8.1.post0=pyhd8ed1ab_0
   - dsdp=5.8=hd9d9efa_1203
   - eccodes=2.29.0=h54fcba4_0
-  - entrypoints=0.4=pyhd8ed1ab_0
   - exceptiongroup=1.2.0=pyhd8ed1ab_2
   - executing=2.0.1=pyhd8ed1ab_0
-  - expat=2.5.0=hcb278e6_1
+  - expat=2.6.2=h59595ed_0
   - ffmpeg=5.1.2=gpl_h8dda1f0_106
   - fftw=3.3.10=nompi_hc118613_108
-  - filelock=3.13.1=pyhd8ed1ab_0
+  - filelock=3.13.4=pyhd8ed1ab_0
   - font-ttf-dejavu-sans-mono=2.37=hab24e00_0
   - font-ttf-inconsolata=3.000=h77eed37_0
   - font-ttf-source-code-pro=2.038=h77eed37_0
@@ -98,77 +88,57 @@ dependencies:
   - fontconfig=2.14.2=h14ed4e7_0
   - fonts-conda-ecosystem=1=0
   - fonts-conda-forge=1=0
-  - fonttools=4.49.0=py311h459d7ec_0
-  - fqdn=1.5.1=pyhd8ed1ab_0
+  - fonttools=4.51.0=py311h459d7ec_0
   - freeglut=3.2.2=h9c3ff4c_1
   - freetype=2.12.1=h267a509_2
   - freexl=1.0.6=h166bdaf_1
-  - fsspec=2024.2.0=pyhca7485f_0
+  - fsspec=2024.3.1=pyhca7485f_0
   - gdal=3.6.2=py311hadb6153_9
   - geos=3.11.1=h27087fc_0
   - geotiff=1.7.1=h7a142b4_6
-  - gettext=0.21.1=h27087fc_0
+  - gettext=0.22.5=h59595ed_2
+  - gettext-tools=0.22.5=h59595ed_2
   - gflags=2.2.2=he1b5a44_1004
-  - giflib=5.2.1=h0b41bf4_3
+  - giflib=5.2.2=hd590300_0
   - glib=2.78.1=hfc55251_0
   - glib-tools=2.78.1=hfc55251_0
   - glog=0.6.0=h6f12383_0
   - glpk=5.0=h445213a_0
-  - gmp=6.3.0=h59595ed_0
+  - gmp=6.3.0=h59595ed_1
   - gnutls=3.7.9=hb077bed_0
-  - graphite2=1.3.13=h58526e2_1001
+  - graphite2=1.3.13=h59595ed_1003
   - gsl=2.7=he838d99_0
   - gst-plugins-base=1.22.0=h4243ec0_2
   - gstreamer=1.22.0=h25f0c4b_2
-  - gstreamer-orc=0.4.37=hd590300_0
-  - h11=0.14.0=pyhd8ed1ab_0
-  - h2=4.1.0=pyhd8ed1ab_0
+  - gstreamer-orc=0.4.38=hd590300_0
   - h5py=3.8.0=nompi_py311h1db17ec_100
   - harfbuzz=6.0.0=h8e241bc_0
   - hdf4=4.2.15=h9772cbc_5
   - hdf5=1.12.2=nompi_h4df4325_101
-  - hpack=4.0.0=pyh9f0ad1d_0
-  - httpcore=1.0.4=pyhd8ed1ab_0
-  - httpx=0.27.0=pyhd8ed1ab_0
-  - hyp3_sdk=6.0.0=pyhd8ed1ab_0
-  - hyperframe=6.0.1=pyhd8ed1ab_0
+  - hyp3_sdk=6.1.0=pyhd8ed1ab_0
   - icu=70.1=h27087fc_0
   - identify=2.5.35=pyhd8ed1ab_0
   - idna=3.6=pyhd8ed1ab_0
   - imagecodecs=2023.1.23=py311ha5a3c35_0
   - imageio=2.34.0=pyh4b66e23_0
-  - importlib-metadata=7.0.1=pyha770c72_0
-  - importlib_metadata=7.0.1=hd8ed1ab_0
-  - importlib_resources=6.1.1=pyhd8ed1ab_0
-  - ipykernel=6.29.2=pyhd33586a_0
+  - importlib-metadata=7.1.0=pyha770c72_0
+  - importlib_metadata=7.1.0=hd8ed1ab_0
+  - ipykernel=6.29.3=pyhd33586a_0
   - ipympl=0.9.3=pyhd8ed1ab_0
-  - ipython=8.21.0=pyh707e725_0
+  - ipython=8.22.2=pyh707e725_0
   - ipython_genutils=0.2.0=py_1
   - ipywidgets=8.1.2=pyhd8ed1ab_0
   - isce2=2.6.3=py311h1e919c0_0
-  - isoduration=20.11.0=pyhd8ed1ab_0
   - jack=1.9.22=h11f4161_0
   - jasper=2.0.33=h0ff4b12_1
   - jedi=0.19.1=pyhd8ed1ab_0
   - jinja2=3.1.3=pyhd8ed1ab_0
   - jmespath=1.0.1=pyhd8ed1ab_0
-  - joblib=1.3.2=pyhd8ed1ab_0
+  - joblib=1.4.0=pyhd8ed1ab_0
   - jpeg=9e=h0b41bf4_3
   - json-c=0.16=hc379101_0
-  - json5=0.9.17=pyhd8ed1ab_0
-  - jsonpointer=2.4=py311h38be061_3
-  - jsonschema=4.21.1=pyhd8ed1ab_0
-  - jsonschema-specifications=2023.12.1=pyhd8ed1ab_0
-  - jsonschema-with-format-nongpl=4.21.1=pyhd8ed1ab_0
-  - jupyter-lsp=2.2.2=pyhd8ed1ab_0
-  - jupyter_client=8.6.0=pyhd8ed1ab_0
-  - jupyter_core=5.7.1=py311h38be061_0
-  - jupyter_events=0.9.0=pyhd8ed1ab_0
-  - jupyter_server=2.12.5=pyhd8ed1ab_0
-  - jupyter_server_terminals=0.5.2=pyhd8ed1ab_0
-  - jupyterlab=4.1.2=pyhd8ed1ab_0
-  - jupyterlab_pygments=0.3.0=pyhd8ed1ab_1
-  - jupyterlab_server=2.25.3=pyhd8ed1ab_0
+  - jupyter_client=8.6.1=pyhd8ed1ab_0
+  - jupyter_core=5.7.2=py311h38be061_0
   - jupyterlab_widgets=3.0.10=pyhd8ed1ab_0
   - jxrlib=1.1=hd590300_3
   - kealib=1.5.0=ha7026e8_0
@@ -176,23 +146,25 @@ dependencies:
   - kiwisolver=1.4.5=py311h9547e67_1
   - krb5=1.20.1=h81ceb04_0
   - lame=3.100=h166bdaf_1003
-  - lazy_loader=0.3=pyhd8ed1ab_0
+  - lazy_loader=0.4=pyhd8ed1ab_0
   - lcms2=2.15=hfd0df8a_0
   - ld_impl_linux-64=2.40=h41732ed_0
   - lerc=4.0.0=h27087fc_0
   - libabseil=20230125.3=cxx17_h59595ed_0
   - libacl=2.3.2=h0f662aa_0
-  - libaec=1.1.2=h59595ed_1
+  - libaec=1.1.3=h59595ed_0
   - libarrow=12.0.1=hd2d78f0_7_cpu
+  - libasprintf=0.22.5=h661eb56_2
+  - libasprintf-devel=0.22.5=h661eb56_2
   - libavif=0.11.1=h8182462_2
-  - libblas=3.9.0=21_linux64_openblas
+  - libblas=3.9.0=22_linux64_openblas
   - libbrotlicommon=1.0.9=h166bdaf_9
   - libbrotlidec=1.0.9=h166bdaf_9
   - libbrotlienc=1.0.9=h166bdaf_9
   - libcap=2.67=he9d0100_0
-  - libcblas=3.9.0=21_linux64_openblas
-  - libclang=15.0.7=default_hb11cfb5_4
-  - libclang13=15.0.7=default_ha2b6cf4_4
+  - libcblas=3.9.0=22_linux64_openblas
+  - libclang=15.0.7=default_h127d8a8_5
+  - libclang13=15.0.7=default_h5d6823c_5
   - libcrc32c=1.1.2=h9c3ff4c_0
   - libcups=2.3.3=h36d4200_3
   - libcurl=8.1.2=h409715c_0
@@ -202,44 +174,46 @@ dependencies:
   - libedit=3.1.20191231=he28a2e2_2
   - libev=4.33=hd590300_2
   - libevent=2.1.10=h28343ad_4
-  - libexpat=2.5.0=hcb278e6_1
+  - libexpat=2.6.2=h59595ed_0
   - libffi=3.4.2=h7f98852_5
   - libflac=1.4.3=h59595ed_0
   - libgcc-ng=13.2.0=h807b86a_5
   - libgcrypt=1.10.3=hd590300_0
   - libgdal=3.6.2=h6c674c2_9
+  - libgettextpo=0.22.5=h59595ed_2
+  - libgettextpo-devel=0.22.5=h59595ed_2
   - libgfortran-ng=13.2.0=h69a702a_5
   - libgfortran5=13.2.0=ha4646dd_5
   - libglib=2.78.1=hebfc3b9_0
   - libglu=9.0.0=he1b5a44_1001
   - libgomp=13.2.0=h807b86a_5
   - libgoogle-cloud=2.12.0=hac9eb74_1
-  - libgpg-error=1.47=h71f35ed_0
+  - libgpg-error=1.48=h71f35ed_0
   - libgrpc=1.54.3=hb20ce57_0
   - libhwloc=2.9.1=hd6dc26d_0
   - libiconv=1.17=hd590300_2
   - libidn2=2.3.7=hd590300_0
   - libkml=1.3.0=h01aab08_1016
-  - liblapack=3.9.0=21_linux64_openblas
-  - liblapacke=3.9.0=21_linux64_openblas
+  - liblapack=3.9.0=22_linux64_openblas
+  - liblapacke=3.9.0=22_linux64_openblas
   - libllvm15=15.0.7=hadd5161_1
   - libnetcdf=4.9.1=nompi_h34a3ff0_101
   - libnghttp2=1.58.0=h47da74e_0
   - libnsl=2.0.1=hd590300_0
-  - libnuma=2.0.16=h0b41bf4_1
+  - libnuma=2.0.18=hd590300_0
   - libogg=1.3.4=h7f98852_1
-  - libopenblas=0.3.26=pthreads_h413a1c8_0
+  - libopenblas=0.3.27=pthreads_h413a1c8_0
   - libopencv=4.6.0=py311ha52ee4f_9
   - libopus=1.3.1=h7f98852_1
   - libpciaccess=0.18=hd590300_0
-  - libpng=1.6.42=h2797004_0
+  - libpng=1.6.43=h2797004_0
   - libpq=15.2=hb675445_0
   - libprotobuf=3.21.12=hfc55251_2
   - librttopo=1.1.0=ha49c73b_12
   - libsndfile=1.2.2=hc60ed4a_1
   - libsodium=1.0.18=h36c2ea0_1
   - libspatialite=5.0.1=h221c8f1_23
-  - libsqlite=3.45.1=h2797004_0
+  - libsqlite=3.45.2=h2797004_0
   - libssh2=1.11.0=h0841786_0
   - libstdcxx-ng=13.2.0=h7e041cc_5
   - libsystemd0=253=h8c4010b_1
@@ -254,7 +228,7 @@ dependencies:
   - libva=2.17.0=h0b41bf4_0
   - libvorbis=1.3.7=h9c3ff4c_0
   - libvpx=1.11.0=h9c3ff4c_3
-  - libwebp-base=1.3.2=hd590300_0
+  - libwebp-base=1.3.2=hd590300_1
   - libxcb=1.13=h7f98852_1004
   - libxkbcommon=1.5.0=h79f4944_1
   - libxml2=2.10.3=hca2bb57_4
@@ -268,29 +242,24 @@ dependencies:
   - lz4-c=1.9.4=hcb278e6_0
   - markdown-it-py=3.0.0=pyhd8ed1ab_0
   - markupsafe=2.1.5=py311h459d7ec_0
-  - matplotlib=3.8.3=py311h38be061_0
-  - matplotlib-base=3.8.3=py311h54ef318_0
+  - matplotlib=3.8.4=py311h38be061_0
+  - matplotlib-base=3.8.4=py311h54ef318_0
   - matplotlib-inline=0.1.6=pyhd8ed1ab_0
   - mdurl=0.1.2=pyhd8ed1ab_0
   - metis=5.1.0=h59595ed_1007
-  - mintpy=1.5.1=pyhd8ed1ab_0
-  - mistune=3.0.2=pyhd8ed1ab_0
-  - mpfr=4.2.1=h9458935_0
-  - mpg123=1.32.4=h59595ed_0
+  - mintpy=1.5.3=pyhd8ed1ab_1
+  - mpfr=4.2.1=h9458935_1
+  - mpg123=1.32.6=h59595ed_0
   - msgpack-python=1.0.7=py311h9547e67_0
   - munkres=1.1.4=pyh9f0ad1d_0
   - mysql-common=8.0.33=hf1915f5_6
   - mysql-libs=8.0.33=hca2cd23_6
-  - nbclient=0.8.0=pyhd8ed1ab_0
-  - nbconvert-core=7.16.1=pyhd8ed1ab_0
-  - nbformat=5.9.2=pyhd8ed1ab_0
-  - ncurses=6.4=h59595ed_2
+  - ncurses=6.4.20240210=h59595ed_0
   - nest-asyncio=1.6.0=pyhd8ed1ab_0
   - netcdf4=1.6.3=nompi_py311ha396515_100
   - nettle=3.9.1=h7ab15ed_0
-  - networkx=3.2.1=pyhd8ed1ab_0
+  - networkx=3.3=pyhd8ed1ab_1
   - nodeenv=1.8.0=pyhd8ed1ab_0
-  - notebook-shim=0.2.4=pyhd8ed1ab_0
   - nspr=4.35=h27087fc_0
   - nss=3.98=h1d7d5a4_0
   - numpy=1.26.4=py311h64a7726_0
@@ -300,12 +269,10 @@ dependencies:
   - openmotif=2.3.8=h5d10074_3
   - openssl=3.1.5=hd590300_0
   - orc=1.9.0=h2f23424_1
-  - overrides=7.7.0=pyhd8ed1ab_0
   - p11-kit=0.24.1=hc5aa10d_0
-  - packaging=23.2=pyhd8ed1ab_0
-  - pandas=2.2.0=py311h320fe9a_0
-  - pandocfilters=1.5.0=pyhd8ed1ab_0
-  - parso=0.8.3=pyhd8ed1ab_0
+  - packaging=24.0=pyhd8ed1ab_0
+  - pandas=2.2.1=py311h320fe9a_0
+  - parso=0.8.4=pyhd8ed1ab_0
   - partd=1.4.1=pyhd8ed1ab_0
   - pcre2=10.40=hc3806b6_0
   - pexpect=4.9.0=pyhd8ed1ab_0
@@ -313,15 +280,13 @@ dependencies:
   - pillow=9.4.0=py311h50def17_1
   - pip=24.0=pyhd8ed1ab_0
   - pixman=0.43.2=h59595ed_0
-  - pkgutil-resolve-name=1.3.10=pyhd8ed1ab_1
   - platformdirs=4.2.0=pyhd8ed1ab_0
-  - ply=3.11=py_1
+  - ply=3.11=pyhd8ed1ab_2
   - poppler=23.03.0=h091648b_0
   - poppler-data=0.4.12=hd8ed1ab_0
   - postgresql=15.2=h3248436_0
-  - pre-commit=3.6.2=pyha770c72_0
+  - pre-commit=3.7.0=pyha770c72_0
   - proj=9.1.1=h8ffa02c_2
-  - prometheus_client=0.20.0=pyhd8ed1ab_0
   - prompt-toolkit=3.0.42=pyha770c72_0
   - psutil=5.9.8=py311h459d7ec_0
   - pthread-stubs=0.4=h36c2ea0_1001
@@ -335,24 +300,22 @@ dependencies:
   - pyaps3=0.3.2=pyhd8ed1ab_1
   - pyarrow=12.0.1=py311h39c9aba_7_cpu
   - pyarrow-hotfix=0.6=pyhd8ed1ab_0
-  - pycparser=2.21=pyhd8ed1ab_0
+  - pycparser=2.22=pyhd8ed1ab_0
   - pygments=2.17.2=pyhd8ed1ab_0
   - pygrib=2.1.4=py311h0acc61a_6
   - pykdtree=1.3.11=py311h1f0f07a_0
   - pykml=0.2.0=pyhd8ed1ab_1
-  - pyparsing=3.1.1=pyhd8ed1ab_0
+  - pyparsing=3.1.2=pyhd8ed1ab_0
   - pyproj=3.5.0=py311h945b3ca_0
   - pyqt=5.15.9=py311hf0fb5b6_5
   - pyqt5-sip=12.12.2=py311hb755f60_5
-  - pyresample=1.28.1=py311h320fe9a_0
-  - pyrocko=2024.01.10=py311h03063b4_0
+  - pyresample=1.28.2=py311h320fe9a_0
+  - pyrocko=2023.10.11=py311h03063b4_0
   - pyshp=2.3.1=pyhd8ed1ab_0
   - pysocks=1.7.1=pyha2e5f31_6
   - pysolid=0.3.2=py311hca9a023_0
   - python=3.11.6=hab00c5b_0_cpython
-  - python-dateutil=2.8.2=pyhd8ed1ab_0
-  - python-fastjsonschema=2.19.1=pyhd8ed1ab_0
-  - python-json-logger=2.0.7=pyhd8ed1ab_0
+  - python-dateutil=2.9.0=pyhd8ed1ab_0
   - python-tzdata=2024.1=pyhd8ed1ab_0
   - python_abi=3.11=4_cp311
   - pytz=2024.1=pyhd8ed1ab_0
@@ -363,70 +326,53 @@ dependencies:
   - rdma-core=28.9=h59595ed_1
   - re2=2023.03.02=h8c504da_0
   - readline=8.2=h8228510_1
-  - referencing=0.33.0=pyhd8ed1ab_0
   - regex=2023.12.25=py311h459d7ec_0
-  - remotezip=0.12.2=pyhd8ed1ab_0
+  - remotezip=0.12.3=pyhd8ed1ab_0
   - requests=2.31.0=pyhd8ed1ab_0
-  - rfc3339-validator=0.1.4=pyhd8ed1ab_0
-  - rfc3986-validator=0.1.1=pyh9f0ad1d_0
-  - rich=13.7.0=pyhd8ed1ab_0
-  - rpds-py=0.18.0=py311h46250e7_0
+  - rich=13.7.1=pyhd8ed1ab_0
   - s2n=1.3.46=h06160fa_0
-  - s3transfer=0.10.0=pyhd8ed1ab_0
+  - s3transfer=0.10.1=pyhd8ed1ab_0
   - sardem=0.11.3=pyhd8ed1ab_0
   - scikit-image=0.22.0=py311h320fe9a_2
-  - scipy=1.12.0=py311h64a7726_2
-  - send2trash=1.8.2=pyh41d4057_0
-  - setuptools=69.1.0=pyhd8ed1ab_1
+  - scipy=1.13.0=py311h64a7726_0
+  - setuptools=69.2.0=pyhd8ed1ab_0
   - shapely=2.0.1=py311h0f577a2_0
   - sip=6.7.12=py311hb755f60_0
   - six=1.16.0=pyh6c4a22f_0
-  - snappy=1.1.10=h9fff704_0
-  - sniffio=1.3.0=pyhd8ed1ab_0
+  - snappy=1.1.10=hdb0a2a9_1
   - sortedcontainers=2.4.0=pyhd8ed1ab_0
-  - soupsieve=2.5=pyhd8ed1ab_1
-  - sqlite=3.45.1=h2c6b66d_0
+  - sqlite=3.45.2=h2c6b66d_0
   - stack_data=0.6.2=pyhd8ed1ab_0
   - suitesparse=5.10.1=h9e50725_1
   - svt-av1=1.4.1=hcb278e6_0
-  - tabulate=0.9.0=pyhd8ed1ab_1
   - tbb=2021.9.0=hf52228f_0
   - tblib=3.0.0=pyhd8ed1ab_0
   - tenacity=8.2.2=pyhd8ed1ab_0
-  - terminado=0.18.0=pyh0d859eb_0
   - tifffile=2023.8.12=pyhd8ed1ab_0
   - tiledb=2.13.2=hd532e3d_0
-  - tinycss2=1.2.1=pyhd8ed1ab_0
   - tk=8.6.13=noxft_h4845f30_101
   - toml=0.10.2=pyhd8ed1ab_0
   - tomli=2.0.1=pyhd8ed1ab_0
   - toolz=0.12.1=pyhd8ed1ab_0
   - tornado=6.4=py311h459d7ec_0
   - tqdm=4.66.2=pyhd8ed1ab_0
-  - traitlets=5.14.1=pyhd8ed1ab_0
-  - types-python-dateutil=2.8.19.20240106=pyhd8ed1ab_0
-  - typing-extensions=4.9.0=hd8ed1ab_0
-  - typing_extensions=4.9.0=pyha770c72_0
-  - typing_utils=0.1.0=pyhd8ed1ab_0
+  - traitlets=5.14.2=pyhd8ed1ab_0
+  - typing_extensions=4.11.0=pyha770c72_0
   - tzcode=2024a=h3f72095_0
   - tzdata=2024a=h0c530f3_0
   - tzlocal=5.2=py311h38be061_0
   - ucx=1.14.1=h64cca9d_5
   - ukkonen=1.0.1=py311h9547e67_4
-  - uri-template=1.3.0=pyhd8ed1ab_0
-  - uriparser=0.9.7=hcb278e6_1
-  - urllib3=2.0.7=pyhd8ed1ab_0
+  - uriparser=0.9.7=h59595ed_1
+  - urllib3=2.2.1=pyhd8ed1ab_0
   - utm=0.7.0=pyhd8ed1ab_0
-  - virtualenv=20.25.0=pyhd8ed1ab_0
+  - virtualenv=20.25.1=pyhd8ed1ab_0
   - wcwidth=0.2.13=pyhd8ed1ab_0
-  - webcolors=1.13=pyhd8ed1ab_0
-  - webencodings=0.5.1=pyhd8ed1ab_2
-  - websocket-client=1.7.0=pyhd8ed1ab_0
-  - wheel=0.42.0=pyhd8ed1ab_0
+  - wheel=0.43.0=pyhd8ed1ab_1
   - widgetsnbextension=4.0.10=pyhd8ed1ab_0
   - x264=1!164.3095=h166bdaf_2
   - x265=3.5=h924138e_3
-  - xarray=2024.2.0=pyhd8ed1ab_0
+  - xarray=2024.3.0=pyhd8ed1ab_0
   - xcb-util=0.4.0=h516909a_0
   - xcb-util-image=0.4.0=h166bdaf_0
   - xcb-util-keysyms=0.4.0=h516909a_0
@@ -453,10 +399,10 @@ dependencies:
   - xorg-renderproto=0.11.1=h7f98852_1002
   - xorg-xextproto=7.3.0=h0b41bf4_1003
   - xorg-xproto=7.0.31=h7f98852_1007
-  - xyzservices=2023.10.1=pyhd8ed1ab_0
+  - xyzservices=2024.4.0=pyhd8ed1ab_0
   - xz=5.2.6=h166bdaf_0
   - yaml=0.2.5=h7f98852_2
-  - zeromq=4.3.5=h59595ed_0
+  - zeromq=4.3.5=h59595ed_1
   - zfp=1.0.1=h59595ed_0
   - zict=3.0.0=pyhd8ed1ab_0
   - zipp=3.17.0=pyhd8ed1ab_0
@@ -467,5 +413,5 @@ dependencies:
       - geojson==3.1.0
       - kite==1.5.8
       - okada-wrapper==18.12.7.3
-      - pyqtgraph==0.13.3
+      - pyqtgraph==0.13.4
       - url-widget==0.0.0


### PR DESCRIPTION
earthscope_insar env:
- pin pyrocko==2023.10.11
    - current version set an env var that breaks conda
- remove unnecessary dependencies:
    - jupyterlab
    - ipywidgets
- remove dependencies installed as deps of other packages:
    - cartopy
    - h5py
    - matplotlib
    - numpy
    - opencv
    - pyproj
    - scikit-image
    - scipy
    - shapely
    - utm